### PR TITLE
Use new Hackvertor tag format

### DIFF
--- a/src/main/kotlin/burpwrappers/ExtensionHelpersAdvanced.kt
+++ b/src/main/kotlin/burpwrappers/ExtensionHelpersAdvanced.kt
@@ -46,14 +46,14 @@ class ExtensionHelpersAdvanced(val helper: IExtensionHelpers) : IExtensionHelper
                 val urlPath = splitted[1]
                 req = BurpExtender.h.stringToBytes("GET /$urlPath HTTP/1.1\r\n" +
                         "Host: $host\r\n" +
-                        "Extension: $extensionName testing if Hackvertor works<@d_url>%0D%0A%0D%0A<@/d_url>")
+                        "Extension: $extensionName testing if Hackvertor works<@d_url>%0D%0A%0D%0A</@d_url>")
                 workingReq = BurpExtender.h.stringToBytes("GET /$urlPath HTTP/1.1\r\n" +
                         "Host: $host\r\n" +
                         "Extension: $extensionName testing if Hackvertor works\r\n\r\n")
             }else{
                 req = BurpExtender.h.stringToBytes("GET / HTTP/1.1\r\n" +
                         "Host: $host\r\n" +
-                        "Extension: $extensionName testing if Hackvertor works<@d_url>%0D%0A%0D%0A<@/d_url>")
+                        "Extension: $extensionName testing if Hackvertor works<@d_url>%0D%0A%0D%0A</@d_url>")
                 workingReq = BurpExtender.h.stringToBytes("GET / HTTP/1.1\r\n" +
                         "Host: $host\r\n" +
                         "Extension: $extensionName testing if Hackvertor works\r\n\r\n")
@@ -64,7 +64,7 @@ class ExtensionHelpersAdvanced(val helper: IExtensionHelpers) : IExtensionHelper
             host = "example.org"
             req = BurpExtender.h.stringToBytes(
                 "GET / HTTP/1.1\r\n" +
-                        "Host: <@d_url><@urlencode_all>example.org<@/urlencode_all><@/d_url>\r\n" +
+                        "Host: <@d_url><@urlencode_all>example.org</@urlencode_all></@d_url>\r\n" +
                         "\r\n")
             workingReq = BurpExtender.h.stringToBytes(
                 "GET / HTTP/1.1\r\n" +

--- a/src/main/kotlin/burpwrappers/builders/UrlPathBuilder.kt
+++ b/src/main/kotlin/burpwrappers/builders/UrlPathBuilder.kt
@@ -14,10 +14,10 @@ class UrlPathBuilder(private val relativeUrl: String){
         cleaned = splitAndDivide(cleaned, "?")
         cleaned = splitAndDivide(cleaned, "#")
         cleaned = splitAndDivide(cleaned, ";")
-        cleaned = cleaned.replace("<@/", randomReplacerForEndHackvertor + "1")
+        cleaned = cleaned.replace("</@", randomReplacerForEndHackvertor + "1")
         cleaned = cleaned.replace("/>", randomReplacerForEndHackvertor + "2")
         val splitted = cleaned.split("/").drop(1)
-        return splitted.map{ it.replace(randomReplacerForEndHackvertor + "2", "/>").replace(randomReplacerForEndHackvertor + "1", "<@/")}
+        return splitted.map{ it.replace(randomReplacerForEndHackvertor + "2", "/>").replace(randomReplacerForEndHackvertor + "1", "</@")}
     }
 
     private fun splitAndDivide(input: String, delimiter: String): String{

--- a/src/main/kotlin/fixer/AlphabeticValue.kt
+++ b/src/main/kotlin/fixer/AlphabeticValue.kt
@@ -11,7 +11,7 @@ class AlphabeticValue(override val entry: LogEntry): Fixer(entry) {
 
     override fun createReplacement(parameter: ParameterAdvanced): List<String> {
         val lengthValue = parameter.value.length
-        val valueFirstOccurrence = "<@set_variable${entry.hackvertorVariable}('false')><@random($lengthValue)>${parameter.value}<@/random><@/set_variable${entry.hackvertorVariable}>"
+        val valueFirstOccurrence = "<@set_variable${entry.hackvertorVariable}('false')><@random($lengthValue)>${parameter.value}</@random></@set_variable${entry.hackvertorVariable}>"
         val valueLaterOccurrence = "<@get_variable${entry.hackvertorVariable} />"
         entry.hackvertorVariable += 1
         return listOf(valueFirstOccurrence, valueLaterOccurrence)

--- a/src/main/kotlin/fixer/BirthdateValue.kt
+++ b/src/main/kotlin/fixer/BirthdateValue.kt
@@ -12,7 +12,7 @@ class BirthdateValue(override val entry: LogEntry): Fixer(entry) {
 
     override fun createReplacement(parameter: ParameterAdvanced): List<String> {
         val startYear = Calendar.getInstance().get(Calendar.YEAR) - 122
-        val valueFirstOccurrence = "<@set_variable${entry.hackvertorVariable}('false')><@arithmetic($startYear,'+',',')><@random_num(2)/><@/arithmetic>-0<@random_num(1)/>-0<@random_num(1)/><@/set_variable${entry.hackvertorVariable}>"
+        val valueFirstOccurrence = "<@set_variable${entry.hackvertorVariable}('false')><@arithmetic($startYear,'+',',')><@random_num(2)/></@arithmetic>-0<@random_num(1)/>-0<@random_num(1)/></@set_variable${entry.hackvertorVariable}>"
         val valueLaterOccurrence = "<@get_variable${entry.hackvertorVariable} />"
         entry.hackvertorVariable += 1
         return listOf(valueFirstOccurrence, valueLaterOccurrence)

--- a/src/main/kotlin/fixer/BooleanValue.kt
+++ b/src/main/kotlin/fixer/BooleanValue.kt
@@ -21,7 +21,7 @@ class BooleanValue(override val entry: LogEntry): Fixer(entry) {
             "0" -> "1"
             else -> parameter.value
         }
-        val newValue = "<@set_variable${entry.hackvertorVariable}('false')>$value<@/set_variable${entry.hackvertorVariable}>"
+        val newValue = "<@set_variable${entry.hackvertorVariable}('false')>$value</@set_variable${entry.hackvertorVariable}>"
         entry.hackvertorVariable += 1
         return listOf(newValue)
     }

--- a/src/main/kotlin/fixer/CharsetValue.kt
+++ b/src/main/kotlin/fixer/CharsetValue.kt
@@ -11,7 +11,7 @@ class CharsetValue(override val entry: LogEntry): Fixer(entry) {
 
     override fun createReplacement(parameter: ParameterAdvanced): List<String> {
         val lengthValue = parameter.value.length
-        val valueFirstOccurrence = "<@set_variable${entry.hackvertorVariable}('false')><@random($lengthValue)>${parameter.value}<@/random><@/set_variable${entry.hackvertorVariable}>"
+        val valueFirstOccurrence = "<@set_variable${entry.hackvertorVariable}('false')><@random($lengthValue)>${parameter.value}</@random></@set_variable${entry.hackvertorVariable}>"
         val valueLaterOccurrence = "<@get_variable${entry.hackvertorVariable} />"
         entry.hackvertorVariable += 1
         return listOf(valueFirstOccurrence, valueLaterOccurrence)

--- a/src/main/kotlin/fixer/DoubleValue.kt
+++ b/src/main/kotlin/fixer/DoubleValue.kt
@@ -17,7 +17,7 @@ class DoubleValue(override val entry: LogEntry): Fixer(entry) {
         }
         val (beforeLength, afterLength) = lengths
         val sign = if("-" in parameter.value) "-" else ""
-        val valueFirstOccurrence = "<@set_variable${entry.hackvertorVariable}('false')>$sign<@random_num(${beforeLength})/>.<@random_num(${afterLength})/><@/set_variable${entry.hackvertorVariable}>"
+        val valueFirstOccurrence = "<@set_variable${entry.hackvertorVariable}('false')>$sign<@random_num(${beforeLength})/>.<@random_num(${afterLength})/></@set_variable${entry.hackvertorVariable}>"
         val valueLaterOccurrence = "<@get_variable${entry.hackvertorVariable} />"
         entry.hackvertorVariable += 1
         return listOf(valueFirstOccurrence, valueLaterOccurrence)

--- a/src/main/kotlin/fixer/EmailValue.kt
+++ b/src/main/kotlin/fixer/EmailValue.kt
@@ -13,13 +13,13 @@ class EmailValue(override val entry: LogEntry): Fixer(entry) {
     override fun createReplacement(parameter: ParameterAdvanced): List<String> {
         val valueFirstOccurrence: String = if(BurpExtender.ui.settings.catchAllEmail.isNotEmpty() &&
             parameter.value.matches(Regex(fullMatchRegexDomain(BurpExtender.ui.settings.catchAllEmail)))){
-            "<@set_variable${entry.hackvertorVariable}('false')><@random_num(12)/><@/set_variable${entry.hackvertorVariable}>@${BurpExtender.ui.settings.catchAllEmail}"
+            "<@set_variable${entry.hackvertorVariable}('false')><@random_num(12)/></@set_variable${entry.hackvertorVariable}>@${BurpExtender.ui.settings.catchAllEmail}"
         }else{
             val colab = BurpExtender.c.createBurpCollaboratorClientContext()?.collaboratorServerLocation
             if(colab != null && parameter.value.matches(Regex(fullMatchRegexDomain(colab))))
-                "<@set_variable${entry.hackvertorVariable}('false')><@random_num(12)/><@/set_variable${entry.hackvertorVariable}>@$colab"
+                "<@set_variable${entry.hackvertorVariable}('false')><@random_num(12)/></@set_variable${entry.hackvertorVariable}>@$colab"
             else
-                "<@set_variable${entry.hackvertorVariable}('false')><@random_num(12)/><@/set_variable${entry.hackvertorVariable}>@$colab"
+                "<@set_variable${entry.hackvertorVariable}('false')><@random_num(12)/></@set_variable${entry.hackvertorVariable}>@$colab"
         }
         val valueLaterOccurrence = "<@get_variable${entry.hackvertorVariable} />"
         entry.hackvertorVariable += 1

--- a/src/main/kotlin/fixer/NumericValue.kt
+++ b/src/main/kotlin/fixer/NumericValue.kt
@@ -12,9 +12,9 @@ class NumericValue(override val entry: LogEntry): Fixer(entry) {
     override fun createReplacement(parameter: ParameterAdvanced): List<String> {
         val lengthValue = parameter.value.length
         val valueFirstOccurrence = if(lengthValue > 1)
-            "<@set_variable${entry.hackvertorVariable}('false')><@arithmetic(${parameter.value},'+',',')><@random_num(${lengthValue - 1})/><@/arithmetic><@/set_variable${entry.hackvertorVariable}>"
+            "<@set_variable${entry.hackvertorVariable}('false')><@arithmetic(${parameter.value},'+',',')><@random_num(${lengthValue - 1})/></@arithmetic></@set_variable${entry.hackvertorVariable}>"
         else
-            "<@set_variable${entry.hackvertorVariable}('false')><@random_num(2)/><@/set_variable${entry.hackvertorVariable}>"
+            "<@set_variable${entry.hackvertorVariable}('false')><@random_num(2)/></@set_variable${entry.hackvertorVariable}>"
         val valueLaterOccurrence = "<@get_variable${entry.hackvertorVariable} />"
         entry.hackvertorVariable += 1
         return listOf(valueFirstOccurrence, valueLaterOccurrence)

--- a/src/main/kotlin/fixer/UnixTimestampMillisecondsValue.kt
+++ b/src/main/kotlin/fixer/UnixTimestampMillisecondsValue.kt
@@ -14,11 +14,11 @@ open class UnixTimestampMillisecondsValue(override val entry: LogEntry): Fixer(e
     override fun createReplacement(parameter: ParameterAdvanced): List<String> {
         val offset = storedOffsets[parameter.uniqueIdentifier()]
         val valueFirstOccurrence = if(offset == null) {
-            "<@set_variable${entry.hackvertorVariable}('false')><@timestamp/><@/set_variable${entry.hackvertorVariable}>"
+            "<@set_variable${entry.hackvertorVariable}('false')><@timestamp/></@set_variable${entry.hackvertorVariable}>"
         }else if(offset > 0.toLong()) {
-            "<@set_variable${entry.hackvertorVariable}('false')><@arithmetic($offset,'+',',')><@timestamp/><@/arithmetic><@/set_variable${entry.hackvertorVariable}>"
+            "<@set_variable${entry.hackvertorVariable}('false')><@arithmetic($offset,'+',',')><@timestamp/></@arithmetic></@set_variable${entry.hackvertorVariable}>"
         }else{
-            "<@set_variable${entry.hackvertorVariable}('false')><@arithmetic(${offset.absoluteValue},'-',',')><@timestamp/><@/arithmetic><@/set_variable${entry.hackvertorVariable}>"
+            "<@set_variable${entry.hackvertorVariable}('false')><@arithmetic(${offset.absoluteValue},'-',',')><@timestamp/></@arithmetic></@set_variable${entry.hackvertorVariable}>"
         }
         val valueLaterOccurrence = "<@get_variable${entry.hackvertorVariable} />"
         entry.hackvertorVariable += 1

--- a/src/main/kotlin/fixer/UuidValue.kt
+++ b/src/main/kotlin/fixer/UuidValue.kt
@@ -11,7 +11,7 @@ class UuidValue(override val entry: LogEntry): Fixer(entry) {
 
     override fun createReplacement(parameter: ParameterAdvanced): List<String> {
         val valueFirstOccurrence =
-            parameter.value.dropLast(12) + "<@set_variable${entry.hackvertorVariable}('false')><@random_num(12)/><@/set_variable${entry.hackvertorVariable}>"
+            parameter.value.dropLast(12) + "<@set_variable${entry.hackvertorVariable}('false')><@random_num(12)/></@set_variable${entry.hackvertorVariable}>"
         val valueLaterOccurrence =
             parameter.value.dropLast(12) + "<@get_variable${entry.hackvertorVariable} />"
         entry.hackvertorVariable += 1


### PR DESCRIPTION
Hi floyd

There is an issue in the current version due to a change in Hackvertor.

## Issue

When I load Pentagrid Scan Controller, I get the following error:

<img  alt="Image" src="https://github.com/user-attachments/assets/9c3c02a6-d98b-4cd7-91da-99d3a63a5cff" />

In the output, I see that it detects the Hackvertor tab:

```
5# Scan Controller loaded
Found Hackvertor tab, seems to be installed, good
```

In Logger, I see the first testing request without Hackvertor tags is successful:

<img  alt="Image" src="https://github.com/user-attachments/assets/95053cf0-d93f-4395-9843-0fba20d136f3" />

However, the 2nd containing a Hackvertor tag fails (no response and the Hackvertor tag cannot be seen as resolved in the Logger):

<img alt="Image" src="https://github.com/user-attachments/assets/a1b30199-8641-468a-ad1d-8806e6ea174c" />

Hackvertor changed the tag style in version 2 from January this year from `<@/name>` to `</@name>` (source: https://github.com/hackvertor/hackvertor?tab=readme-ov-file#changelog):

<img  alt="Image" src="https://github.com/user-attachments/assets/2d3a7bc4-4198-4f23-9b98-7da76bad07ca" />

This means the extension cannot use Hackvertor tags at the moment.

## Fix

I just search/replaced the tags to fix it.

The new build works as expected:

<img alt="image" src="https://github.com/user-attachments/assets/e106196e-3f2f-461b-b178-5325080d4211" />

The request that failed before works now (newlines correctly added to the end of the request):

<img alt="image" src="https://github.com/user-attachments/assets/a70bbc6a-3e6b-4f1f-913d-d9be652858a8" />


However, still a very nice extension :)!

Best,
Mänu